### PR TITLE
Fix: 404 error on page refresh in Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,11 @@
   "outputDirectory": "dist/spa",
   "env": {
     "NODE_ENV": "production"
-  }
+  },
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
**Purpose:**

The user encountered a "404: NOT_FOUND" error on their Vercel deployment when directly accessing or refreshing any page other than the root. The goal was to resolve this issue to ensure all routes are accessible directly and after a page refresh.

**Code changes:**

- Modified the `vercel.json` file to include a `rewrites` rule.
- This rule `{"source": "/(.*)", "destination": "/index.html"}` ensures that all incoming requests are redirected to the `index.html` file.
- This allows the client-side router to handle the routing for the single-page application (SPA), preventing the 404 errors.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/11a40903e73e498298e8c694e2b6bb94/nova-zone)

👀 [Preview Link](https://11a40903e73e498298e8c694e2b6bb94-nova-zone.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>11a40903e73e498298e8c694e2b6bb94</projectId>-->
<!--<branchName>nova-zone</branchName>-->