### PR TITLE
feat: Update "Foot" color in header and footer

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
                 <span className="text-white font-bold">SF</span>
               </div>
               <span className="font-display text-lg font-bold">
-                StoriesByFoot
+                StoriesBy<span className="text-primary">Foot</span>
               </span>
             </div>
             <p className="text-gray-300 text-sm">

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -36,7 +36,7 @@ export default function Header() {
               <span className="text-white font-bold text-lg">SF</span>
             </div>
             <span className="hidden sm:inline font-display text-xl font-bold text-foreground">
-              StoriesByFoot
+              StoriesBy<span className="text-primary">Foot</span>
             </span>
           </Link>
 


### PR DESCRIPTION
### Purpose

The user requested to change the color of the word "Foot" in "StoriesByFoot" in both the header and the footer. The goal is to match the color used for "next adventure" in the hero section to create a more consistent design.

### Code changes

- In `client/components/Footer.tsx` and `client/components/Header.tsx`, the hardcoded text "StoriesByFoot" was updated.
- The word "Foot" is now enclosed within a `<span>` tag.
- The `className="text-primary"` is applied to this `<span>` to style the word "Foot" with the application's primary color.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac0b4bf6eab2424bb2eb23d54a008f15/zen-field)

👀 [Preview Link](https://ac0b4bf6eab2424bb2eb23d54a008f15-zen-field.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac0b4bf6eab2424bb2eb23d54a008f15</projectId>-->
<!--<branchName>zen-field</branchName>-->