### PR TITLE
feat: Make 'Foot' text bold in header and footer

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
                 <span className="text-white font-bold">SF</span>
               </div>
               <span className="font-display text-lg font-bold">
-                StoriesBy<span className="text-primary">Foot</span>
+                StoriesBy<span className="text-primary font-bold">Foot</span>
               </span>
             </div>
             <p className="text-gray-300 text-sm">

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -36,7 +36,7 @@ export default function Header() {
               <span className="text-white font-bold text-lg">SF</span>
             </div>
             <span className="hidden sm:inline font-display text-xl font-bold text-foreground">
-              StoriesBy<span className="text-primary">Foot</span>
+              StoriesBy<span className="text-primary font-bold">Foot</span>
             </span>
           </Link>
 


### PR DESCRIPTION
### Purpose

The user wanted to make the "Foot" part of the "StoriesByFoot" text bold in both the header and footer of the application.

### Code changes

- In `Header.tsx`, the `font-bold` class was added to the `<span>` that wraps the text "Foot".
- In `Footer.tsx`, the `font-bold` class was added to the `<span>` that wraps the text "Foot".

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac0b4bf6eab2424bb2eb23d54a008f15/nova-haven)

👀 [Preview Link](https://ac0b4bf6eab2424bb2eb23d54a008f15-nova-haven.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac0b4bf6eab2424bb2eb23d54a008f15</projectId>-->
<!--<branchName>nova-haven</branchName>-->