### PR TITLE
Update copyright year to 2025

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -143,7 +143,7 @@ export default function Footer() {
         <div className="border-t border-gray-700 pt-8">
           <div className="flex flex-col md:flex-row justify-between items-center gap-4">
             <p className="text-gray-400 text-sm">
-              © 2024 StoriesByFoot. All rights reserved.
+              © 2025 StoriesByFoot. All rights reserved.
             </p>
             <div className="flex gap-6">
               <a


### PR DESCRIPTION
### Purpose

Based on the conversation history, the user's goal was to update the copyright year in the footer from 2024 to 2025.

### Code changes

The code has been updated to change the copyright year from 2024 to 2025 in the `Footer.tsx` component.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac0b4bf6eab2424bb2eb23d54a008f15/orbit-home)

👀 [Preview Link](https://ac0b4bf6eab2424bb2eb23d54a008f15-orbit-home.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac0b4bf6eab2424bb2eb23d54a008f15</projectId>-->
<!--<branchName>orbit-home</branchName>-->