### PR TITLE
feat: Increase footer logo text size to match header

### DIFF
--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -21,7 +21,7 @@ export default function Footer() {
                 alt="StoriesByFoot"
                 className="w-10 h-10 object-contain"
               />
-              <span className="font-display text-lg font-bold">
+              <span className="font-display text-xl font-bold">
                 StoriesBy<span className="text-primary">Foot</span>
               </span>
             </div>


### PR DESCRIPTION
### Purpose

The user observed that the "StoriesByFoot" logo text in the footer was smaller than in the header. The goal of this change is to make the logo text size consistent across the header and footer by increasing the font size in the footer.

### Code changes

- In `client/components/Footer.tsx`, the `className` for the `<span>` element containing the "StoriesByFoot" text has been updated from `text-lg` to `text-xl`.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac0b4bf6eab2424bb2eb23d54a008f15/mystic-zone)

👀 [Preview Link](https://ac0b4bf6eab2424bb2eb23d54a008f15-mystic-zone.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac0b4bf6eab2424bb2eb23d54a008f15</projectId>-->
<!--<branchName>mystic-zone</branchName>-->