### PR TITLE
feat: Add pages for footer policy links

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -39,7 +39,10 @@ export default function App() {
             <Route path="/register" element={<Register />} />
             <Route path="/privacy-policy" element={<PrivacyPolicy />} />
             <Route path="/cookie-policy" element={<CookiePolicy />} />
-            <Route path="/terms-and-conditions" element={<TermsAndConditions />} />
+            <Route
+              path="/terms-and-conditions"
+              element={<TermsAndConditions />}
+            />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -14,6 +14,9 @@ import Testimonials from "./pages/Testimonials";
 import Contact from "./pages/Contact";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import CookiePolicy from "./pages/CookiePolicy";
+import TermsAndConditions from "./pages/TermsAndConditions";
 
 const queryClient = new QueryClient();
 
@@ -34,6 +37,9 @@ export default function App() {
             <Route path="/contact" element={<Contact />} />
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
+            <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+            <Route path="/cookie-policy" element={<CookiePolicy />} />
+            <Route path="/terms-and-conditions" element={<TermsAndConditions />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/client/components/Footer.tsx
+++ b/client/components/Footer.tsx
@@ -91,28 +91,28 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <a
-                  href="#"
+                <Link
+                  to="/privacy-policy"
                   className="text-gray-300 hover:text-primary transition-colors text-sm"
                 >
                   Privacy Policy
-                </a>
+                </Link>
               </li>
               <li>
-                <a
-                  href="#"
+                <Link
+                  to="/cookie-policy"
                   className="text-gray-300 hover:text-primary transition-colors text-sm"
                 >
                   Cookie Policy
-                </a>
+                </Link>
               </li>
               <li>
-                <a
-                  href="#"
+                <Link
+                  to="/terms-and-conditions"
                   className="text-gray-300 hover:text-primary transition-colors text-sm"
                 >
-                  Terms and Condition
-                </a>
+                  Terms and Conditions
+                </Link>
               </li>
             </ul>
           </div>

--- a/client/pages/CookiePolicy.tsx
+++ b/client/pages/CookiePolicy.tsx
@@ -1,0 +1,187 @@
+import Layout from "@/components/Layout";
+
+export default function CookiePolicy() {
+  return (
+    <Layout>
+      {/* Hero Section */}
+      <section className="bg-gradient-to-br from-blue-50 to-orange-50 py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="text-5xl md:text-6xl font-display font-bold text-foreground mb-6">
+            Cookie Policy
+          </h1>
+          <p className="text-xl text-gray-600 max-w-2xl">
+            Understand how we use cookies and similar technologies to enhance your experience.
+          </p>
+        </div>
+      </section>
+
+      {/* Content Section */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="prose prose-lg max-w-none">
+            {/* Introduction */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">What Are Cookies?</h2>
+              <p className="text-gray-700 mb-4">
+                Cookies are small text files that are placed on your device when you visit our website. They contain information about your browsing activities and are used to remember your preferences and improve your user experience.
+              </p>
+            </div>
+
+            {/* Types of Cookies */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Types of Cookies We Use</h2>
+              
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Essential Cookies</h3>
+                <p className="text-gray-700 mb-4">
+                  These cookies are necessary for the website to function properly. They enable basic functions like page navigation and access to secure areas. Without these cookies, the website cannot operate effectively.
+                </p>
+                <ul className="list-disc list-inside text-gray-700 space-y-2">
+                  <li>Session management</li>
+                  <li>Authentication</li>
+                  <li>Security and fraud detection</li>
+                </ul>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Performance Cookies</h3>
+                <p className="text-gray-700 mb-4">
+                  These cookies collect information about how you use our website, such as which pages you visit most often and if you encounter error messages. This helps us improve site performance.
+                </p>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Functionality Cookies</h3>
+                <p className="text-gray-700 mb-4">
+                  These cookies allow the website to remember your choices and preferences, such as your language, location, and login information. They provide a more personalized experience.
+                </p>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Marketing Cookies</h3>
+                <p className="text-gray-700 mb-4">
+                  These cookies track your browsing activity to help us show you relevant advertisements and marketing content. They may be shared with advertising partners.
+                </p>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Analytics Cookies</h3>
+                <p className="text-gray-700 mb-4">
+                  These cookies help us understand how visitors interact with our website, including the number of visitors, traffic sources, and user behavior patterns. This information helps us improve our services.
+                </p>
+              </div>
+            </div>
+
+            {/* First-Party vs Third-Party */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">First-Party and Third-Party Cookies</h2>
+              
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">First-Party Cookies</h3>
+                <p className="text-gray-700">
+                  These are cookies set directly by StoriesByFoot and are used to remember your preferences and improve your experience on our website.
+                </p>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Third-Party Cookies</h3>
+                <p className="text-gray-700">
+                  These cookies are set by external services and partners, such as analytics providers, advertising networks, and social media platforms. These cookies may track your activity across multiple websites.
+                </p>
+              </div>
+            </div>
+
+            {/* Specific Services */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Cookies from External Services</h2>
+              <p className="text-gray-700 mb-4">We use cookies from the following services:</p>
+              
+              <div className="space-y-4">
+                <div className="border-l-4 border-primary pl-4">
+                  <h3 className="font-semibold text-gray-800">Google Analytics</h3>
+                  <p className="text-gray-700 text-sm">
+                    Used to analyze website traffic and user behavior. Privacy Policy: https://policies.google.com/privacy
+                  </p>
+                </div>
+                
+                <div className="border-l-4 border-primary pl-4">
+                  <h3 className="font-semibold text-gray-800">Payment Processors</h3>
+                  <p className="text-gray-700 text-sm">
+                    Used for secure payment processing and transaction management.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-primary pl-4">
+                  <h3 className="font-semibold text-gray-800">Social Media Platforms</h3>
+                  <p className="text-gray-700 text-sm">
+                    Used for social sharing features and integration. Facebook, Instagram, and Twitter may set cookies.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            {/* Cookie Duration */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Cookie Duration</h2>
+              <p className="text-gray-700 mb-4">Cookies can be:</p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li><strong>Session Cookies:</strong> Deleted when you close your browser</li>
+                <li><strong>Persistent Cookies:</strong> Remain on your device for a set period or until you delete them</li>
+              </ul>
+            </div>
+
+            {/* Managing Cookies */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">How to Manage Cookies</h2>
+              <p className="text-gray-700 mb-4">
+                You have the right to accept, refuse, or delete cookies. You can control cookies through:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Browser settings (most browsers allow you to refuse cookies or alert you when cookies are being sent)</li>
+                <li>Opt-out mechanisms provided on our website</li>
+                <li>Clearing your browser history and cookies</li>
+              </ul>
+              <p className="text-gray-700 mt-4">
+                Please note that disabling essential cookies may affect the functionality of our website.
+              </p>
+            </div>
+
+            {/* GDPR and Privacy */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">GDPR Compliance</h2>
+              <p className="text-gray-700 mb-4">
+                For users in the European Union and other jurisdictions with privacy laws similar to GDPR, we comply with applicable regulations regarding consent and cookie management. We obtain your explicit consent before placing non-essential cookies on your device.
+              </p>
+            </div>
+
+            {/* Changes to This Policy */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Changes to This Policy</h2>
+              <p className="text-gray-700 mb-4">
+                We may update this Cookie Policy from time to time to reflect changes in our cookie practices or for other operational, legal, or regulatory reasons. We will notify you of significant changes by posting the updated policy on our website.
+              </p>
+            </div>
+
+            {/* Contact Us */}
+            <div className="bg-gradient-to-br from-blue-50 to-orange-50 rounded-lg p-8">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Contact Us</h2>
+              <p className="text-gray-700 mb-4">
+                If you have questions about our Cookie Policy or how we use cookies, please contact us at:
+              </p>
+              <div className="space-y-2 text-gray-700">
+                <p><strong>Email:</strong> contact@storiesbyfoot.com</p>
+                <p><strong>Phone:</strong> +91 62051 29118</p>
+                <p><strong>Address:</strong> New Delhi, India</p>
+              </div>
+            </div>
+
+            {/* Last Updated */}
+            <div className="mt-8 text-center text-gray-500 text-sm">
+              <p>Last Updated: January 2025</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/client/pages/CookiePolicy.tsx
+++ b/client/pages/CookiePolicy.tsx
@@ -10,7 +10,8 @@ export default function CookiePolicy() {
             Cookie Policy
           </h1>
           <p className="text-xl text-gray-600 max-w-2xl">
-            Understand how we use cookies and similar technologies to enhance your experience.
+            Understand how we use cookies and similar technologies to enhance
+            your experience.
           </p>
         </div>
       </section>
@@ -21,20 +22,32 @@ export default function CookiePolicy() {
           <div className="prose prose-lg max-w-none">
             {/* Introduction */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">What Are Cookies?</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                What Are Cookies?
+              </h2>
               <p className="text-gray-700 mb-4">
-                Cookies are small text files that are placed on your device when you visit our website. They contain information about your browsing activities and are used to remember your preferences and improve your user experience.
+                Cookies are small text files that are placed on your device when
+                you visit our website. They contain information about your
+                browsing activities and are used to remember your preferences
+                and improve your user experience.
               </p>
             </div>
 
             {/* Types of Cookies */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Types of Cookies We Use</h2>
-              
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Types of Cookies We Use
+              </h2>
+
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Essential Cookies</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Essential Cookies
+                </h3>
                 <p className="text-gray-700 mb-4">
-                  These cookies are necessary for the website to function properly. They enable basic functions like page navigation and access to secure areas. Without these cookies, the website cannot operate effectively.
+                  These cookies are necessary for the website to function
+                  properly. They enable basic functions like page navigation and
+                  access to secure areas. Without these cookies, the website
+                  cannot operate effectively.
                 </p>
                 <ul className="list-disc list-inside text-gray-700 space-y-2">
                   <li>Session management</li>
@@ -44,77 +57,119 @@ export default function CookiePolicy() {
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Performance Cookies</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Performance Cookies
+                </h3>
                 <p className="text-gray-700 mb-4">
-                  These cookies collect information about how you use our website, such as which pages you visit most often and if you encounter error messages. This helps us improve site performance.
+                  These cookies collect information about how you use our
+                  website, such as which pages you visit most often and if you
+                  encounter error messages. This helps us improve site
+                  performance.
                 </p>
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Functionality Cookies</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Functionality Cookies
+                </h3>
                 <p className="text-gray-700 mb-4">
-                  These cookies allow the website to remember your choices and preferences, such as your language, location, and login information. They provide a more personalized experience.
+                  These cookies allow the website to remember your choices and
+                  preferences, such as your language, location, and login
+                  information. They provide a more personalized experience.
                 </p>
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Marketing Cookies</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Marketing Cookies
+                </h3>
                 <p className="text-gray-700 mb-4">
-                  These cookies track your browsing activity to help us show you relevant advertisements and marketing content. They may be shared with advertising partners.
+                  These cookies track your browsing activity to help us show you
+                  relevant advertisements and marketing content. They may be
+                  shared with advertising partners.
                 </p>
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Analytics Cookies</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Analytics Cookies
+                </h3>
                 <p className="text-gray-700 mb-4">
-                  These cookies help us understand how visitors interact with our website, including the number of visitors, traffic sources, and user behavior patterns. This information helps us improve our services.
+                  These cookies help us understand how visitors interact with
+                  our website, including the number of visitors, traffic
+                  sources, and user behavior patterns. This information helps us
+                  improve our services.
                 </p>
               </div>
             </div>
 
             {/* First-Party vs Third-Party */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">First-Party and Third-Party Cookies</h2>
-              
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                First-Party and Third-Party Cookies
+              </h2>
+
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">First-Party Cookies</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  First-Party Cookies
+                </h3>
                 <p className="text-gray-700">
-                  These are cookies set directly by StoriesByFoot and are used to remember your preferences and improve your experience on our website.
+                  These are cookies set directly by StoriesByFoot and are used
+                  to remember your preferences and improve your experience on
+                  our website.
                 </p>
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Third-Party Cookies</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Third-Party Cookies
+                </h3>
                 <p className="text-gray-700">
-                  These cookies are set by external services and partners, such as analytics providers, advertising networks, and social media platforms. These cookies may track your activity across multiple websites.
+                  These cookies are set by external services and partners, such
+                  as analytics providers, advertising networks, and social media
+                  platforms. These cookies may track your activity across
+                  multiple websites.
                 </p>
               </div>
             </div>
 
             {/* Specific Services */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Cookies from External Services</h2>
-              <p className="text-gray-700 mb-4">We use cookies from the following services:</p>
-              
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Cookies from External Services
+              </h2>
+              <p className="text-gray-700 mb-4">
+                We use cookies from the following services:
+              </p>
+
               <div className="space-y-4">
                 <div className="border-l-4 border-primary pl-4">
-                  <h3 className="font-semibold text-gray-800">Google Analytics</h3>
+                  <h3 className="font-semibold text-gray-800">
+                    Google Analytics
+                  </h3>
                   <p className="text-gray-700 text-sm">
-                    Used to analyze website traffic and user behavior. Privacy Policy: https://policies.google.com/privacy
-                  </p>
-                </div>
-                
-                <div className="border-l-4 border-primary pl-4">
-                  <h3 className="font-semibold text-gray-800">Payment Processors</h3>
-                  <p className="text-gray-700 text-sm">
-                    Used for secure payment processing and transaction management.
+                    Used to analyze website traffic and user behavior. Privacy
+                    Policy: https://policies.google.com/privacy
                   </p>
                 </div>
 
                 <div className="border-l-4 border-primary pl-4">
-                  <h3 className="font-semibold text-gray-800">Social Media Platforms</h3>
+                  <h3 className="font-semibold text-gray-800">
+                    Payment Processors
+                  </h3>
                   <p className="text-gray-700 text-sm">
-                    Used for social sharing features and integration. Facebook, Instagram, and Twitter may set cookies.
+                    Used for secure payment processing and transaction
+                    management.
+                  </p>
+                </div>
+
+                <div className="border-l-4 border-primary pl-4">
+                  <h3 className="font-semibold text-gray-800">
+                    Social Media Platforms
+                  </h3>
+                  <p className="text-gray-700 text-sm">
+                    Used for social sharing features and integration. Facebook,
+                    Instagram, and Twitter may set cookies.
                   </p>
                 </div>
               </div>
@@ -122,56 +177,91 @@ export default function CookiePolicy() {
 
             {/* Cookie Duration */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Cookie Duration</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Cookie Duration
+              </h2>
               <p className="text-gray-700 mb-4">Cookies can be:</p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
-                <li><strong>Session Cookies:</strong> Deleted when you close your browser</li>
-                <li><strong>Persistent Cookies:</strong> Remain on your device for a set period or until you delete them</li>
+                <li>
+                  <strong>Session Cookies:</strong> Deleted when you close your
+                  browser
+                </li>
+                <li>
+                  <strong>Persistent Cookies:</strong> Remain on your device for
+                  a set period or until you delete them
+                </li>
               </ul>
             </div>
 
             {/* Managing Cookies */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">How to Manage Cookies</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                How to Manage Cookies
+              </h2>
               <p className="text-gray-700 mb-4">
-                You have the right to accept, refuse, or delete cookies. You can control cookies through:
+                You have the right to accept, refuse, or delete cookies. You can
+                control cookies through:
               </p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
-                <li>Browser settings (most browsers allow you to refuse cookies or alert you when cookies are being sent)</li>
+                <li>
+                  Browser settings (most browsers allow you to refuse cookies or
+                  alert you when cookies are being sent)
+                </li>
                 <li>Opt-out mechanisms provided on our website</li>
                 <li>Clearing your browser history and cookies</li>
               </ul>
               <p className="text-gray-700 mt-4">
-                Please note that disabling essential cookies may affect the functionality of our website.
+                Please note that disabling essential cookies may affect the
+                functionality of our website.
               </p>
             </div>
 
             {/* GDPR and Privacy */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">GDPR Compliance</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                GDPR Compliance
+              </h2>
               <p className="text-gray-700 mb-4">
-                For users in the European Union and other jurisdictions with privacy laws similar to GDPR, we comply with applicable regulations regarding consent and cookie management. We obtain your explicit consent before placing non-essential cookies on your device.
+                For users in the European Union and other jurisdictions with
+                privacy laws similar to GDPR, we comply with applicable
+                regulations regarding consent and cookie management. We obtain
+                your explicit consent before placing non-essential cookies on
+                your device.
               </p>
             </div>
 
             {/* Changes to This Policy */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Changes to This Policy</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Changes to This Policy
+              </h2>
               <p className="text-gray-700 mb-4">
-                We may update this Cookie Policy from time to time to reflect changes in our cookie practices or for other operational, legal, or regulatory reasons. We will notify you of significant changes by posting the updated policy on our website.
+                We may update this Cookie Policy from time to time to reflect
+                changes in our cookie practices or for other operational, legal,
+                or regulatory reasons. We will notify you of significant changes
+                by posting the updated policy on our website.
               </p>
             </div>
 
             {/* Contact Us */}
             <div className="bg-gradient-to-br from-blue-50 to-orange-50 rounded-lg p-8">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Contact Us</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Contact Us
+              </h2>
               <p className="text-gray-700 mb-4">
-                If you have questions about our Cookie Policy or how we use cookies, please contact us at:
+                If you have questions about our Cookie Policy or how we use
+                cookies, please contact us at:
               </p>
               <div className="space-y-2 text-gray-700">
-                <p><strong>Email:</strong> contact@storiesbyfoot.com</p>
-                <p><strong>Phone:</strong> +91 62051 29118</p>
-                <p><strong>Address:</strong> New Delhi, India</p>
+                <p>
+                  <strong>Email:</strong> contact@storiesbyfoot.com
+                </p>
+                <p>
+                  <strong>Phone:</strong> +91 62051 29118
+                </p>
+                <p>
+                  <strong>Address:</strong> New Delhi, India
+                </p>
               </div>
             </div>
 

--- a/client/pages/PrivacyPolicy.tsx
+++ b/client/pages/PrivacyPolicy.tsx
@@ -10,7 +10,8 @@ export default function PrivacyPolicy() {
             Privacy Policy
           </h1>
           <p className="text-xl text-gray-600 max-w-2xl">
-            Your privacy is important to us. Learn how we collect and protect your data.
+            Your privacy is important to us. Learn how we collect and protect
+            your data.
           </p>
         </div>
       </section>
@@ -21,31 +22,49 @@ export default function PrivacyPolicy() {
           <div className="prose prose-lg max-w-none">
             {/* Introduction */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Introduction</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Introduction
+              </h2>
               <p className="text-gray-700 mb-4">
-                StoriesByFoot ("Company," "we," "us," or "our") operates the website and mobile applications. This Privacy Policy explains our practices regarding the collection, use, and disclosure of your information when you use our services.
+                StoriesByFoot ("Company," "we," "us," or "our") operates the
+                website and mobile applications. This Privacy Policy explains
+                our practices regarding the collection, use, and disclosure of
+                your information when you use our services.
               </p>
             </div>
 
             {/* Information We Collect */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Information We Collect</h2>
-              
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Information We Collect
+              </h2>
+
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Personal Information</h3>
-                <p className="text-gray-700 mb-4">We collect information you provide directly to us, including:</p>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Personal Information
+                </h3>
+                <p className="text-gray-700 mb-4">
+                  We collect information you provide directly to us, including:
+                </p>
                 <ul className="list-disc list-inside text-gray-700 space-y-2">
                   <li>Name, email address, and phone number</li>
                   <li>Billing and shipping addresses</li>
-                  <li>Payment information (processed securely through third-party providers)</li>
+                  <li>
+                    Payment information (processed securely through third-party
+                    providers)
+                  </li>
                   <li>Travel preferences and booking history</li>
                   <li>Communications and correspondence</li>
                 </ul>
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Automatically Collected Information</h3>
-                <p className="text-gray-700 mb-4">When you use our services, we automatically collect:</p>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Automatically Collected Information
+                </h3>
+                <p className="text-gray-700 mb-4">
+                  When you use our services, we automatically collect:
+                </p>
                 <ul className="list-disc list-inside text-gray-700 space-y-2">
                   <li>Browser and device information</li>
                   <li>IP address and location data</li>
@@ -58,8 +77,12 @@ export default function PrivacyPolicy() {
 
             {/* How We Use Your Information */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">How We Use Your Information</h2>
-              <p className="text-gray-700 mb-4">We use the information we collect to:</p>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                How We Use Your Information
+              </h2>
+              <p className="text-gray-700 mb-4">
+                We use the information we collect to:
+              </p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
                 <li>Process bookings and payments</li>
                 <li>Provide customer support and respond to inquiries</li>
@@ -73,30 +96,46 @@ export default function PrivacyPolicy() {
 
             {/* Information Sharing */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">How We Share Your Information</h2>
-              <p className="text-gray-700 mb-4">We may share your information with:</p>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                How We Share Your Information
+              </h2>
+              <p className="text-gray-700 mb-4">
+                We may share your information with:
+              </p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
-                <li>Service providers and partners necessary to fulfill your requests</li>
+                <li>
+                  Service providers and partners necessary to fulfill your
+                  requests
+                </li>
                 <li>Payment processors for secure transactions</li>
                 <li>Analytics providers to improve our services</li>
                 <li>Law enforcement when required by law</li>
               </ul>
               <p className="text-gray-700 mt-4">
-                We do not sell your personal information to third parties for marketing purposes.
+                We do not sell your personal information to third parties for
+                marketing purposes.
               </p>
             </div>
 
             {/* Data Security */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Data Security</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Data Security
+              </h2>
               <p className="text-gray-700 mb-4">
-                We implement appropriate technical and organizational measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction. However, no method of transmission over the internet is 100% secure, and we cannot guarantee absolute security.
+                We implement appropriate technical and organizational measures
+                to protect your personal information against unauthorized
+                access, alteration, disclosure, or destruction. However, no
+                method of transmission over the internet is 100% secure, and we
+                cannot guarantee absolute security.
               </p>
             </div>
 
             {/* Your Rights */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Your Rights</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Your Rights
+              </h2>
               <p className="text-gray-700 mb-4">You have the right to:</p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
                 <li>Access the personal information we hold about you</li>
@@ -106,44 +145,68 @@ export default function PrivacyPolicy() {
                 <li>Request a copy of your data</li>
               </ul>
               <p className="text-gray-700 mt-4">
-                To exercise these rights, please contact us at contact@storiesbyfoot.com
+                To exercise these rights, please contact us at
+                contact@storiesbyfoot.com
               </p>
             </div>
 
             {/* Cookies and Tracking */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Cookies and Tracking Technologies</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Cookies and Tracking Technologies
+              </h2>
               <p className="text-gray-700 mb-4">
-                We use cookies and similar technologies to enhance your experience. For detailed information about cookies, please see our Cookie Policy.
+                We use cookies and similar technologies to enhance your
+                experience. For detailed information about cookies, please see
+                our Cookie Policy.
               </p>
             </div>
 
             {/* Children's Privacy */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Children's Privacy</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Children's Privacy
+              </h2>
               <p className="text-gray-700 mb-4">
-                Our services are not directed to children under 13 years of age. We do not knowingly collect personal information from children under 13. If we become aware that we have collected information from a child under 13, we will take steps to delete such information.
+                Our services are not directed to children under 13 years of age.
+                We do not knowingly collect personal information from children
+                under 13. If we become aware that we have collected information
+                from a child under 13, we will take steps to delete such
+                information.
               </p>
             </div>
 
             {/* Changes to This Policy */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Changes to This Policy</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Changes to This Policy
+              </h2>
               <p className="text-gray-700 mb-4">
-                We may update this Privacy Policy from time to time. We will notify you of significant changes by posting the updated policy on our website with an updated "Last Updated" date.
+                We may update this Privacy Policy from time to time. We will
+                notify you of significant changes by posting the updated policy
+                on our website with an updated "Last Updated" date.
               </p>
             </div>
 
             {/* Contact Us */}
             <div className="bg-gradient-to-br from-blue-50 to-orange-50 rounded-lg p-8">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Contact Us</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Contact Us
+              </h2>
               <p className="text-gray-700 mb-4">
-                If you have questions about this Privacy Policy or our privacy practices, please contact us at:
+                If you have questions about this Privacy Policy or our privacy
+                practices, please contact us at:
               </p>
               <div className="space-y-2 text-gray-700">
-                <p><strong>Email:</strong> contact@storiesbyfoot.com</p>
-                <p><strong>Phone:</strong> +91 62051 29118</p>
-                <p><strong>Address:</strong> New Delhi, India</p>
+                <p>
+                  <strong>Email:</strong> contact@storiesbyfoot.com
+                </p>
+                <p>
+                  <strong>Phone:</strong> +91 62051 29118
+                </p>
+                <p>
+                  <strong>Address:</strong> New Delhi, India
+                </p>
               </div>
             </div>
 

--- a/client/pages/PrivacyPolicy.tsx
+++ b/client/pages/PrivacyPolicy.tsx
@@ -1,0 +1,159 @@
+import Layout from "@/components/Layout";
+
+export default function PrivacyPolicy() {
+  return (
+    <Layout>
+      {/* Hero Section */}
+      <section className="bg-gradient-to-br from-blue-50 to-orange-50 py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="text-5xl md:text-6xl font-display font-bold text-foreground mb-6">
+            Privacy Policy
+          </h1>
+          <p className="text-xl text-gray-600 max-w-2xl">
+            Your privacy is important to us. Learn how we collect and protect your data.
+          </p>
+        </div>
+      </section>
+
+      {/* Content Section */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="prose prose-lg max-w-none">
+            {/* Introduction */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Introduction</h2>
+              <p className="text-gray-700 mb-4">
+                StoriesByFoot ("Company," "we," "us," or "our") operates the website and mobile applications. This Privacy Policy explains our practices regarding the collection, use, and disclosure of your information when you use our services.
+              </p>
+            </div>
+
+            {/* Information We Collect */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Information We Collect</h2>
+              
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Personal Information</h3>
+                <p className="text-gray-700 mb-4">We collect information you provide directly to us, including:</p>
+                <ul className="list-disc list-inside text-gray-700 space-y-2">
+                  <li>Name, email address, and phone number</li>
+                  <li>Billing and shipping addresses</li>
+                  <li>Payment information (processed securely through third-party providers)</li>
+                  <li>Travel preferences and booking history</li>
+                  <li>Communications and correspondence</li>
+                </ul>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Automatically Collected Information</h3>
+                <p className="text-gray-700 mb-4">When you use our services, we automatically collect:</p>
+                <ul className="list-disc list-inside text-gray-700 space-y-2">
+                  <li>Browser and device information</li>
+                  <li>IP address and location data</li>
+                  <li>Cookies and similar tracking technologies</li>
+                  <li>Pages visited and links clicked</li>
+                  <li>Referring website information</li>
+                </ul>
+              </div>
+            </div>
+
+            {/* How We Use Your Information */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">How We Use Your Information</h2>
+              <p className="text-gray-700 mb-4">We use the information we collect to:</p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Process bookings and payments</li>
+                <li>Provide customer support and respond to inquiries</li>
+                <li>Send transactional and promotional communications</li>
+                <li>Improve our website and services</li>
+                <li>Conduct analytics and understand user behavior</li>
+                <li>Comply with legal obligations</li>
+                <li>Prevent fraud and ensure security</li>
+              </ul>
+            </div>
+
+            {/* Information Sharing */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">How We Share Your Information</h2>
+              <p className="text-gray-700 mb-4">We may share your information with:</p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Service providers and partners necessary to fulfill your requests</li>
+                <li>Payment processors for secure transactions</li>
+                <li>Analytics providers to improve our services</li>
+                <li>Law enforcement when required by law</li>
+              </ul>
+              <p className="text-gray-700 mt-4">
+                We do not sell your personal information to third parties for marketing purposes.
+              </p>
+            </div>
+
+            {/* Data Security */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Data Security</h2>
+              <p className="text-gray-700 mb-4">
+                We implement appropriate technical and organizational measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction. However, no method of transmission over the internet is 100% secure, and we cannot guarantee absolute security.
+              </p>
+            </div>
+
+            {/* Your Rights */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Your Rights</h2>
+              <p className="text-gray-700 mb-4">You have the right to:</p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Access the personal information we hold about you</li>
+                <li>Correct inaccurate or incomplete information</li>
+                <li>Request deletion of your information</li>
+                <li>Opt-out of promotional communications</li>
+                <li>Request a copy of your data</li>
+              </ul>
+              <p className="text-gray-700 mt-4">
+                To exercise these rights, please contact us at contact@storiesbyfoot.com
+              </p>
+            </div>
+
+            {/* Cookies and Tracking */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Cookies and Tracking Technologies</h2>
+              <p className="text-gray-700 mb-4">
+                We use cookies and similar technologies to enhance your experience. For detailed information about cookies, please see our Cookie Policy.
+              </p>
+            </div>
+
+            {/* Children's Privacy */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Children's Privacy</h2>
+              <p className="text-gray-700 mb-4">
+                Our services are not directed to children under 13 years of age. We do not knowingly collect personal information from children under 13. If we become aware that we have collected information from a child under 13, we will take steps to delete such information.
+              </p>
+            </div>
+
+            {/* Changes to This Policy */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Changes to This Policy</h2>
+              <p className="text-gray-700 mb-4">
+                We may update this Privacy Policy from time to time. We will notify you of significant changes by posting the updated policy on our website with an updated "Last Updated" date.
+              </p>
+            </div>
+
+            {/* Contact Us */}
+            <div className="bg-gradient-to-br from-blue-50 to-orange-50 rounded-lg p-8">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Contact Us</h2>
+              <p className="text-gray-700 mb-4">
+                If you have questions about this Privacy Policy or our privacy practices, please contact us at:
+              </p>
+              <div className="space-y-2 text-gray-700">
+                <p><strong>Email:</strong> contact@storiesbyfoot.com</p>
+                <p><strong>Phone:</strong> +91 62051 29118</p>
+                <p><strong>Address:</strong> New Delhi, India</p>
+              </div>
+            </div>
+
+            {/* Last Updated */}
+            <div className="mt-8 text-center text-gray-500 text-sm">
+              <p>Last Updated: January 2025</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/client/pages/TermsAndConditions.tsx
+++ b/client/pages/TermsAndConditions.tsx
@@ -21,22 +21,40 @@ export default function TermsAndConditions() {
           <div className="prose prose-lg max-w-none">
             {/* Introduction */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Agreement to Terms</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Agreement to Terms
+              </h2>
               <p className="text-gray-700 mb-4">
-                These Terms and Conditions ("Agreement") constitute a legal agreement between you and StoriesByFoot ("Company," "we," "us," or "our"). By accessing or using our website, booking expeditions, or using our services, you agree to be bound by these terms. If you do not agree to any part of these terms, you should not use our services.
+                These Terms and Conditions ("Agreement") constitute a legal
+                agreement between you and StoriesByFoot ("Company," "we," "us,"
+                or "our"). By accessing or using our website, booking
+                expeditions, or using our services, you agree to be bound by
+                these terms. If you do not agree to any part of these terms, you
+                should not use our services.
               </p>
             </div>
 
             {/* Use License */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Use License</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Use License
+              </h2>
               <p className="text-gray-700 mb-4">
-                We grant you a non-exclusive, non-transferable license to use our website and services for personal, non-commercial purposes, subject to the restrictions in these Terms and Conditions. You may not:
+                We grant you a non-exclusive, non-transferable license to use
+                our website and services for personal, non-commercial purposes,
+                subject to the restrictions in these Terms and Conditions. You
+                may not:
               </p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
-                <li>Modify, copy, or reproduce any part of the website or services</li>
-                <li>Use any automated tools to access or monitor the website</li>
-                <li>Engage in unauthorized access, interference, or disruption</li>
+                <li>
+                  Modify, copy, or reproduce any part of the website or services
+                </li>
+                <li>
+                  Use any automated tools to access or monitor the website
+                </li>
+                <li>
+                  Engage in unauthorized access, interference, or disruption
+                </li>
                 <li>Collect or use personal information about other users</li>
                 <li>Attempt to hack or gain unauthorized access</li>
               </ul>
@@ -44,77 +62,126 @@ export default function TermsAndConditions() {
 
             {/* Booking and Payment */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Booking and Payment Terms</h2>
-              
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Booking and Payment Terms
+              </h2>
+
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Expedition Bookings</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Expedition Bookings
+                </h3>
                 <p className="text-gray-700 mb-4">
-                  When you book an expedition through our website, you are entering into a binding agreement with StoriesByFoot. You agree to:
+                  When you book an expedition through our website, you are
+                  entering into a binding agreement with StoriesByFoot. You
+                  agree to:
                 </p>
                 <ul className="list-disc list-inside text-gray-700 space-y-2">
                   <li>Provide accurate and complete information</li>
-                  <li>Pay the full expedition cost according to our pricing terms</li>
+                  <li>
+                    Pay the full expedition cost according to our pricing terms
+                  </li>
                   <li>Comply with all cancellation and refund policies</li>
                   <li>Follow all safety guidelines and expedition rules</li>
                 </ul>
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Payment</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Payment
+                </h3>
                 <p className="text-gray-700 mb-4">
-                  All payments must be made in full unless otherwise agreed. We accept various payment methods. Payment details are processed securely through third-party payment processors. You are responsible for maintaining the confidentiality of your payment information.
+                  All payments must be made in full unless otherwise agreed. We
+                  accept various payment methods. Payment details are processed
+                  securely through third-party payment processors. You are
+                  responsible for maintaining the confidentiality of your
+                  payment information.
                 </p>
               </div>
 
               <div className="mb-8">
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">Pricing</h3>
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                  Pricing
+                </h3>
                 <p className="text-gray-700">
-                  Prices are subject to change without notice. The price at the time of booking is the price you are obligated to pay, unless otherwise specified in your booking confirmation.
+                  Prices are subject to change without notice. The price at the
+                  time of booking is the price you are obligated to pay, unless
+                  otherwise specified in your booking confirmation.
                 </p>
               </div>
             </div>
 
             {/* Cancellation and Refunds */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Cancellation and Refund Policy</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Cancellation and Refund Policy
+              </h2>
               <p className="text-gray-700 mb-4">
-                Cancellation policies vary by expedition and are detailed in your booking confirmation. Generally:
+                Cancellation policies vary by expedition and are detailed in
+                your booking confirmation. Generally:
               </p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
-                <li>Cancellations 30+ days before the expedition may qualify for a full refund (minus any fees)</li>
-                <li>Cancellations 15-29 days before may incur a 50% cancellation fee</li>
-                <li>Cancellations less than 15 days before may result in no refund</li>
+                <li>
+                  Cancellations 30+ days before the expedition may qualify for a
+                  full refund (minus any fees)
+                </li>
+                <li>
+                  Cancellations 15-29 days before may incur a 50% cancellation
+                  fee
+                </li>
+                <li>
+                  Cancellations less than 15 days before may result in no refund
+                </li>
               </ul>
               <p className="text-gray-700 mt-4">
-                All refunds will be processed within 14 business days. For specific details, please refer to your booking confirmation or contact us directly.
+                All refunds will be processed within 14 business days. For
+                specific details, please refer to your booking confirmation or
+                contact us directly.
               </p>
             </div>
 
             {/* Participant Responsibilities */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Participant Responsibilities</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Participant Responsibilities
+              </h2>
               <p className="text-gray-700 mb-4">
                 As a participant in our expeditions, you are responsible for:
               </p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
-                <li>Ensuring you are physically and mentally fit for the expedition</li>
+                <li>
+                  Ensuring you are physically and mentally fit for the
+                  expedition
+                </li>
                 <li>Disclosing any medical conditions or allergies</li>
-                <li>Obtaining necessary travel documents (passport, visa, permits)</li>
+                <li>
+                  Obtaining necessary travel documents (passport, visa, permits)
+                </li>
                 <li>Obtaining travel insurance (highly recommended)</li>
-                <li>Following all safety instructions and expedition guidelines</li>
+                <li>
+                  Following all safety instructions and expedition guidelines
+                </li>
                 <li>Respecting local customs and regulations</li>
-                <li>Complying with all laws applicable in the destination country</li>
+                <li>
+                  Complying with all laws applicable in the destination country
+                </li>
               </ul>
             </div>
 
             {/* Risk Disclaimer */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Assumption of Risk and Liability Waiver</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Assumption of Risk and Liability Waiver
+              </h2>
               <p className="text-gray-700 mb-4">
-                Expeditions involve inherent risks including but not limited to altitude sickness, accidents, weather-related incidents, and personal injury. By booking an expedition, you acknowledge and assume all risks associated with participation.
+                Expeditions involve inherent risks including but not limited to
+                altitude sickness, accidents, weather-related incidents, and
+                personal injury. By booking an expedition, you acknowledge and
+                assume all risks associated with participation.
               </p>
               <p className="text-gray-700 mb-4">
-                You agree to release, indemnify, and hold harmless StoriesByFoot, its employees, partners, and agents from any and all claims, damages, liabilities, and expenses arising from:
+                You agree to release, indemnify, and hold harmless
+                StoriesByFoot, its employees, partners, and agents from any and
+                all claims, damages, liabilities, and expenses arising from:
               </p>
               <ul className="list-disc list-inside text-gray-700 space-y-2">
                 <li>Personal injury or death</li>
@@ -127,89 +194,143 @@ export default function TermsAndConditions() {
 
             {/* Insurance */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Travel Insurance</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Travel Insurance
+              </h2>
               <p className="text-gray-700">
-                We strongly recommend obtaining comprehensive travel insurance that covers medical emergencies, evacuation, trip cancellation, and baggage loss. StoriesByFoot is not responsible for losses not covered by your insurance.
+                We strongly recommend obtaining comprehensive travel insurance
+                that covers medical emergencies, evacuation, trip cancellation,
+                and baggage loss. StoriesByFoot is not responsible for losses
+                not covered by your insurance.
               </p>
             </div>
 
             {/* Intellectual Property */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Intellectual Property Rights</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Intellectual Property Rights
+              </h2>
               <p className="text-gray-700 mb-4">
-                All content on our website, including text, images, photographs, videos, and graphics, is the property of StoriesByFoot or its content suppliers and is protected by copyright and other intellectual property laws.
+                All content on our website, including text, images, photographs,
+                videos, and graphics, is the property of StoriesByFoot or its
+                content suppliers and is protected by copyright and other
+                intellectual property laws.
               </p>
               <p className="text-gray-700">
-                You may not reproduce, distribute, or transmit any content without our prior written consent.
+                You may not reproduce, distribute, or transmit any content
+                without our prior written consent.
               </p>
             </div>
 
             {/* User-Generated Content */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">User-Generated Content</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                User-Generated Content
+              </h2>
               <p className="text-gray-700 mb-4">
-                If you submit photos, reviews, testimonials, or other content to StoriesByFoot, you grant us a worldwide, royalty-free license to use, reproduce, and display that content for marketing and promotional purposes.
+                If you submit photos, reviews, testimonials, or other content to
+                StoriesByFoot, you grant us a worldwide, royalty-free license to
+                use, reproduce, and display that content for marketing and
+                promotional purposes.
               </p>
             </div>
 
             {/* Disclaimer of Warranties */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Disclaimer of Warranties</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Disclaimer of Warranties
+              </h2>
               <p className="text-gray-700">
-                Our website and services are provided "as is" without warranties of any kind. We do not warrant that our services will be uninterrupted, error-free, or free from viruses or malware. We disclaim all implied warranties, including merchantability, fitness for a particular purpose, and non-infringement.
+                Our website and services are provided "as is" without warranties
+                of any kind. We do not warrant that our services will be
+                uninterrupted, error-free, or free from viruses or malware. We
+                disclaim all implied warranties, including merchantability,
+                fitness for a particular purpose, and non-infringement.
               </p>
             </div>
 
             {/* Limitation of Liability */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Limitation of Liability</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Limitation of Liability
+              </h2>
               <p className="text-gray-700">
-                To the maximum extent permitted by law, StoriesByFoot shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of our services, even if we have been advised of the possibility of such damages.
+                To the maximum extent permitted by law, StoriesByFoot shall not
+                be liable for any indirect, incidental, special, consequential,
+                or punitive damages arising from your use of our services, even
+                if we have been advised of the possibility of such damages.
               </p>
             </div>
 
             {/* Governing Law */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Governing Law</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Governing Law
+              </h2>
               <p className="text-gray-700">
-                These Terms and Conditions are governed by and construed in accordance with the laws of India, and you irrevocably submit to the exclusive jurisdiction of the courts located in New Delhi.
+                These Terms and Conditions are governed by and construed in
+                accordance with the laws of India, and you irrevocably submit to
+                the exclusive jurisdiction of the courts located in New Delhi.
               </p>
             </div>
 
             {/* Modifications */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Modifications to Terms</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Modifications to Terms
+              </h2>
               <p className="text-gray-700">
-                We reserve the right to modify these Terms and Conditions at any time. Modifications will be effective immediately upon posting to the website. Your continued use of our services constitutes your acceptance of the modified terms.
+                We reserve the right to modify these Terms and Conditions at any
+                time. Modifications will be effective immediately upon posting
+                to the website. Your continued use of our services constitutes
+                your acceptance of the modified terms.
               </p>
             </div>
 
             {/* Termination */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Termination</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Termination
+              </h2>
               <p className="text-gray-700">
-                We reserve the right to terminate or suspend your access to our services at any time, with or without notice, for any reason including violation of these Terms and Conditions.
+                We reserve the right to terminate or suspend your access to our
+                services at any time, with or without notice, for any reason
+                including violation of these Terms and Conditions.
               </p>
             </div>
 
             {/* Severability */}
             <div className="mb-12">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Severability</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Severability
+              </h2>
               <p className="text-gray-700">
-                If any provision of these Terms and Conditions is found to be invalid or unenforceable, that provision shall be modified to the minimum extent necessary to make it valid, and the remaining provisions shall remain in full force and effect.
+                If any provision of these Terms and Conditions is found to be
+                invalid or unenforceable, that provision shall be modified to
+                the minimum extent necessary to make it valid, and the remaining
+                provisions shall remain in full force and effect.
               </p>
             </div>
 
             {/* Contact Us */}
             <div className="bg-gradient-to-br from-blue-50 to-orange-50 rounded-lg p-8">
-              <h2 className="text-3xl font-bold text-foreground mb-4">Questions?</h2>
+              <h2 className="text-3xl font-bold text-foreground mb-4">
+                Questions?
+              </h2>
               <p className="text-gray-700 mb-4">
-                If you have questions about these Terms and Conditions, please contact us at:
+                If you have questions about these Terms and Conditions, please
+                contact us at:
               </p>
               <div className="space-y-2 text-gray-700">
-                <p><strong>Email:</strong> contact@storiesbyfoot.com</p>
-                <p><strong>Phone:</strong> +91 62051 29118</p>
-                <p><strong>Address:</strong> New Delhi, India</p>
+                <p>
+                  <strong>Email:</strong> contact@storiesbyfoot.com
+                </p>
+                <p>
+                  <strong>Phone:</strong> +91 62051 29118
+                </p>
+                <p>
+                  <strong>Address:</strong> New Delhi, India
+                </p>
               </div>
             </div>
 

--- a/client/pages/TermsAndConditions.tsx
+++ b/client/pages/TermsAndConditions.tsx
@@ -1,0 +1,225 @@
+import Layout from "@/components/Layout";
+
+export default function TermsAndConditions() {
+  return (
+    <Layout>
+      {/* Hero Section */}
+      <section className="bg-gradient-to-br from-blue-50 to-orange-50 py-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h1 className="text-5xl md:text-6xl font-display font-bold text-foreground mb-6">
+            Terms and Conditions
+          </h1>
+          <p className="text-xl text-gray-600 max-w-2xl">
+            Please read these terms carefully before using our services.
+          </p>
+        </div>
+      </section>
+
+      {/* Content Section */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="prose prose-lg max-w-none">
+            {/* Introduction */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Agreement to Terms</h2>
+              <p className="text-gray-700 mb-4">
+                These Terms and Conditions ("Agreement") constitute a legal agreement between you and StoriesByFoot ("Company," "we," "us," or "our"). By accessing or using our website, booking expeditions, or using our services, you agree to be bound by these terms. If you do not agree to any part of these terms, you should not use our services.
+              </p>
+            </div>
+
+            {/* Use License */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Use License</h2>
+              <p className="text-gray-700 mb-4">
+                We grant you a non-exclusive, non-transferable license to use our website and services for personal, non-commercial purposes, subject to the restrictions in these Terms and Conditions. You may not:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Modify, copy, or reproduce any part of the website or services</li>
+                <li>Use any automated tools to access or monitor the website</li>
+                <li>Engage in unauthorized access, interference, or disruption</li>
+                <li>Collect or use personal information about other users</li>
+                <li>Attempt to hack or gain unauthorized access</li>
+              </ul>
+            </div>
+
+            {/* Booking and Payment */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Booking and Payment Terms</h2>
+              
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Expedition Bookings</h3>
+                <p className="text-gray-700 mb-4">
+                  When you book an expedition through our website, you are entering into a binding agreement with StoriesByFoot. You agree to:
+                </p>
+                <ul className="list-disc list-inside text-gray-700 space-y-2">
+                  <li>Provide accurate and complete information</li>
+                  <li>Pay the full expedition cost according to our pricing terms</li>
+                  <li>Comply with all cancellation and refund policies</li>
+                  <li>Follow all safety guidelines and expedition rules</li>
+                </ul>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Payment</h3>
+                <p className="text-gray-700 mb-4">
+                  All payments must be made in full unless otherwise agreed. We accept various payment methods. Payment details are processed securely through third-party payment processors. You are responsible for maintaining the confidentiality of your payment information.
+                </p>
+              </div>
+
+              <div className="mb-8">
+                <h3 className="text-xl font-semibold text-gray-800 mb-3">Pricing</h3>
+                <p className="text-gray-700">
+                  Prices are subject to change without notice. The price at the time of booking is the price you are obligated to pay, unless otherwise specified in your booking confirmation.
+                </p>
+              </div>
+            </div>
+
+            {/* Cancellation and Refunds */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Cancellation and Refund Policy</h2>
+              <p className="text-gray-700 mb-4">
+                Cancellation policies vary by expedition and are detailed in your booking confirmation. Generally:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Cancellations 30+ days before the expedition may qualify for a full refund (minus any fees)</li>
+                <li>Cancellations 15-29 days before may incur a 50% cancellation fee</li>
+                <li>Cancellations less than 15 days before may result in no refund</li>
+              </ul>
+              <p className="text-gray-700 mt-4">
+                All refunds will be processed within 14 business days. For specific details, please refer to your booking confirmation or contact us directly.
+              </p>
+            </div>
+
+            {/* Participant Responsibilities */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Participant Responsibilities</h2>
+              <p className="text-gray-700 mb-4">
+                As a participant in our expeditions, you are responsible for:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Ensuring you are physically and mentally fit for the expedition</li>
+                <li>Disclosing any medical conditions or allergies</li>
+                <li>Obtaining necessary travel documents (passport, visa, permits)</li>
+                <li>Obtaining travel insurance (highly recommended)</li>
+                <li>Following all safety instructions and expedition guidelines</li>
+                <li>Respecting local customs and regulations</li>
+                <li>Complying with all laws applicable in the destination country</li>
+              </ul>
+            </div>
+
+            {/* Risk Disclaimer */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Assumption of Risk and Liability Waiver</h2>
+              <p className="text-gray-700 mb-4">
+                Expeditions involve inherent risks including but not limited to altitude sickness, accidents, weather-related incidents, and personal injury. By booking an expedition, you acknowledge and assume all risks associated with participation.
+              </p>
+              <p className="text-gray-700 mb-4">
+                You agree to release, indemnify, and hold harmless StoriesByFoot, its employees, partners, and agents from any and all claims, damages, liabilities, and expenses arising from:
+              </p>
+              <ul className="list-disc list-inside text-gray-700 space-y-2">
+                <li>Personal injury or death</li>
+                <li>Loss or damage to personal property</li>
+                <li>Actions or omissions of third parties</li>
+                <li>Weather conditions or natural disasters</li>
+                <li>Medical emergencies or evacuation costs</li>
+              </ul>
+            </div>
+
+            {/* Insurance */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Travel Insurance</h2>
+              <p className="text-gray-700">
+                We strongly recommend obtaining comprehensive travel insurance that covers medical emergencies, evacuation, trip cancellation, and baggage loss. StoriesByFoot is not responsible for losses not covered by your insurance.
+              </p>
+            </div>
+
+            {/* Intellectual Property */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Intellectual Property Rights</h2>
+              <p className="text-gray-700 mb-4">
+                All content on our website, including text, images, photographs, videos, and graphics, is the property of StoriesByFoot or its content suppliers and is protected by copyright and other intellectual property laws.
+              </p>
+              <p className="text-gray-700">
+                You may not reproduce, distribute, or transmit any content without our prior written consent.
+              </p>
+            </div>
+
+            {/* User-Generated Content */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">User-Generated Content</h2>
+              <p className="text-gray-700 mb-4">
+                If you submit photos, reviews, testimonials, or other content to StoriesByFoot, you grant us a worldwide, royalty-free license to use, reproduce, and display that content for marketing and promotional purposes.
+              </p>
+            </div>
+
+            {/* Disclaimer of Warranties */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Disclaimer of Warranties</h2>
+              <p className="text-gray-700">
+                Our website and services are provided "as is" without warranties of any kind. We do not warrant that our services will be uninterrupted, error-free, or free from viruses or malware. We disclaim all implied warranties, including merchantability, fitness for a particular purpose, and non-infringement.
+              </p>
+            </div>
+
+            {/* Limitation of Liability */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Limitation of Liability</h2>
+              <p className="text-gray-700">
+                To the maximum extent permitted by law, StoriesByFoot shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of our services, even if we have been advised of the possibility of such damages.
+              </p>
+            </div>
+
+            {/* Governing Law */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Governing Law</h2>
+              <p className="text-gray-700">
+                These Terms and Conditions are governed by and construed in accordance with the laws of India, and you irrevocably submit to the exclusive jurisdiction of the courts located in New Delhi.
+              </p>
+            </div>
+
+            {/* Modifications */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Modifications to Terms</h2>
+              <p className="text-gray-700">
+                We reserve the right to modify these Terms and Conditions at any time. Modifications will be effective immediately upon posting to the website. Your continued use of our services constitutes your acceptance of the modified terms.
+              </p>
+            </div>
+
+            {/* Termination */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Termination</h2>
+              <p className="text-gray-700">
+                We reserve the right to terminate or suspend your access to our services at any time, with or without notice, for any reason including violation of these Terms and Conditions.
+              </p>
+            </div>
+
+            {/* Severability */}
+            <div className="mb-12">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Severability</h2>
+              <p className="text-gray-700">
+                If any provision of these Terms and Conditions is found to be invalid or unenforceable, that provision shall be modified to the minimum extent necessary to make it valid, and the remaining provisions shall remain in full force and effect.
+              </p>
+            </div>
+
+            {/* Contact Us */}
+            <div className="bg-gradient-to-br from-blue-50 to-orange-50 rounded-lg p-8">
+              <h2 className="text-3xl font-bold text-foreground mb-4">Questions?</h2>
+              <p className="text-gray-700 mb-4">
+                If you have questions about these Terms and Conditions, please contact us at:
+              </p>
+              <div className="space-y-2 text-gray-700">
+                <p><strong>Email:</strong> contact@storiesbyfoot.com</p>
+                <p><strong>Phone:</strong> +91 62051 29118</p>
+                <p><strong>Address:</strong> New Delhi, India</p>
+              </div>
+            </div>
+
+            {/* Last Updated */}
+            <div className="mt-8 text-center text-gray-500 text-sm">
+              <p>Last Updated: January 2025</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}


### PR DESCRIPTION
### Purpose

Based on the conversation history, the user wanted to make the footer links for "Privacy Policy," "Cookie Policy," and "Terms and Conditions" functional. The goal was to create dedicated pages for each of these policies and ensure they are correctly linked from the website's footer.

### Code changes

- **Page Creation**: Added three new pages: `PrivacyPolicy.tsx`, `CookiePolicy.tsx`, and `TermsAndConditions.tsx` to provide content for the respective legal policies.
- **Routing**: Introduced new routes in `App.tsx` to handle navigation to `/privacy-policy`, `/cookie-policy`, and `/terms-and-conditions`.
- **Footer Linking**: Updated `Footer.tsx` to replace the placeholder `<a>` tags with `Link` components from `react-router-dom`, connecting the footer links to the newly created pages.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac0b4bf6eab2424bb2eb23d54a008f15/pixel-haven)

👀 [Preview Link](https://ac0b4bf6eab2424bb2eb23d54a008f15-pixel-haven.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac0b4bf6eab2424bb2eb23d54a008f15</projectId>-->
<!--<branchName>pixel-haven</branchName>-->