### PR TITLE
Fix: Ensure pages open at the top on navigation

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -4,7 +4,8 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import { useEffect } from "react";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Destinations from "./pages/Destinations";
@@ -20,6 +21,16 @@ import TermsAndConditions from "./pages/TermsAndConditions";
 
 const queryClient = new QueryClient();
 
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -27,6 +38,7 @@ export default function App() {
         <Toaster />
         <Sonner />
         <BrowserRouter>
+          <ScrollToTop />
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/destinations" element={<Destinations />} />

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -25,7 +25,8 @@ function ScrollToTop() {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
   }, [pathname]);
 
   return null;

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -25,8 +25,9 @@ function ScrollToTop() {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    document.documentElement.scrollTop = 0;
-    document.body.scrollTop = 0;
+    setTimeout(() => {
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+    }, 0);
   }, [pathname]);
 
   return null;

--- a/client/global.css
+++ b/client/global.css
@@ -97,7 +97,7 @@
   }
 
   html {
-    @apply scroll-smooth;
+    scroll-behavior: auto;
   }
 
   body {


### PR DESCRIPTION
### Purpose

The user wants to change the page navigation behavior. When clicking on links, such as those in the footer or on the homepage, the user wants the new page to load directly at the top, instead of scrolling up from the bottom.

### Code changes

- **`client/App.tsx`**:
    - Introduced a `ScrollToTop` component that utilizes the `useLocation` hook to detect route changes.
    - On a route change, it programmatically scrolls the window to the top instantly.
    - This component has been integrated at the root level of the application within the `<BrowserRouter>`.

- **`client/global.css`**:
    - Removed the `scroll-smooth` utility class from the `html` element.
    - Replaced it with `scroll-behavior: auto;` to disable the default smooth scrolling behavior and allow for instant scrolling.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/ac0b4bf6eab2424bb2eb23d54a008f15/quantum-nest)

👀 [Preview Link](https://ac0b4bf6eab2424bb2eb23d54a008f15-quantum-nest.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ac0b4bf6eab2424bb2eb23d54a008f15</projectId>-->
<!--<branchName>quantum-nest</branchName>-->