### PR TITLE
feat: Set INR as default and base currency for conversions

### DIFF
--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -83,15 +83,15 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
   });
 
   const { data: rates = {}, isLoading } = useQuery({
-    queryKey: ["exchangeRates", currency],
-    queryFn: () => fetchExchangeRates(currency),
-    staleTime: 1000 * 60 * 5, // 5 minutes
-    refetchInterval: 1000 * 60 * 5, // Refresh every 5 minutes
+    queryKey: ["exchangeRates"],
+    queryFn: () => fetchExchangeRates("USD"),
+    staleTime: 1000 * 60 * 5,
+    refetchInterval: 1000 * 60 * 5,
     refetchOnWindowFocus: false,
   });
 
   const ratesMap = useMemo(() => {
-    const map: Record<string, number> = { [currency]: 1 };
+    const map: Record<string, number> = { USD: 1 };
     if (rates && typeof rates === "object") {
       for (const [code, rate] of Object.entries(rates)) {
         if (typeof rate === "number" && rate > 0) {
@@ -100,7 +100,7 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
       }
     }
     return map;
-  }, [rates, currency]);
+  }, [rates]);
 
   const convertPrice = (
     basePrice: number,

--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -42,15 +42,21 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   KWD: "د.ك",
 };
 
-async function fetchExchangeRates(baseCurrency: string): Promise<Record<string, number>> {
+async function fetchExchangeRates(
+  baseCurrency: string,
+): Promise<Record<string, number>> {
   try {
     const res = await fetch(
-      `https://api.exchangerate.host/latest?base=${baseCurrency}`
+      `https://api.exchangerate.host/latest?base=${baseCurrency}`,
     );
     if (res.ok) {
       const data = await res.json();
       if (data.rates && typeof data.rates === "object") {
-        console.log(`Exchange rates fetched for base ${baseCurrency}:`, Object.keys(data.rates).length, "currencies");
+        console.log(
+          `Exchange rates fetched for base ${baseCurrency}:`,
+          Object.keys(data.rates).length,
+          "currencies",
+        );
         return data.rates as Record<string, number>;
       }
     }
@@ -60,12 +66,16 @@ async function fetchExchangeRates(baseCurrency: string): Promise<Record<string, 
 
   try {
     const res = await fetch(
-      `https://api.frankfurter.app/latest?from=${baseCurrency}`
+      `https://api.frankfurter.app/latest?from=${baseCurrency}`,
     );
     if (res.ok) {
       const data = await res.json();
       if (data.rates && typeof data.rates === "object") {
-        console.log(`Fallback rates fetched for base ${baseCurrency}:`, Object.keys(data.rates).length, "currencies");
+        console.log(
+          `Fallback rates fetched for base ${baseCurrency}:`,
+          Object.keys(data.rates).length,
+          "currencies",
+        );
         return data.rates as Record<string, number>;
       }
     }
@@ -107,7 +117,7 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
 
   const convertPrice = (
     basePrice: number,
-    fromCurrency: string = "USD"
+    fromCurrency: string = "USD",
   ): number => {
     if (!Number.isFinite(basePrice)) return 0;
 
@@ -119,7 +129,7 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
     // Debug logging
     if (process.env.NODE_ENV === "development") {
       console.log(
-        `Convert ${basePrice} from ${fromCurrency} to ${currency}: ${fromRate} -> ${toRate} = ${result}`
+        `Convert ${basePrice} from ${fromCurrency} to ${currency}: ${fromRate} -> ${toRate} = ${result}`,
       );
     }
 
@@ -128,7 +138,7 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
 
   const formatPrice = (
     basePrice: number,
-    fromCurrency: string = "USD"
+    fromCurrency: string = "USD",
   ): string => {
     const converted = convertPrice(basePrice, fromCurrency);
     const symbol = getSymbol(currency);

--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -87,14 +87,14 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
 
   const { data: rates = {}, isLoading } = useQuery({
     queryKey: ["exchangeRates"],
-    queryFn: () => fetchExchangeRates("USD"),
+    queryFn: () => fetchExchangeRates("INR"),
     staleTime: 1000 * 60 * 5,
     refetchInterval: 1000 * 60 * 5,
     refetchOnWindowFocus: false,
   });
 
   const ratesMap = useMemo(() => {
-    const map: Record<string, number> = { USD: 1 };
+    const map: Record<string, number> = { INR: 1 };
     if (rates && typeof rates === "object") {
       for (const [code, rate] of Object.entries(rates)) {
         if (typeof rate === "number" && rate > 0) {

--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -50,6 +50,7 @@ async function fetchExchangeRates(baseCurrency: string): Promise<Record<string, 
     if (res.ok) {
       const data = await res.json();
       if (data.rates && typeof data.rates === "object") {
+        console.log(`Exchange rates fetched for base ${baseCurrency}:`, Object.keys(data.rates).length, "currencies");
         return data.rates as Record<string, number>;
       }
     }
@@ -64,6 +65,7 @@ async function fetchExchangeRates(baseCurrency: string): Promise<Record<string, 
     if (res.ok) {
       const data = await res.json();
       if (data.rates && typeof data.rates === "object") {
+        console.log(`Fallback rates fetched for base ${baseCurrency}:`, Object.keys(data.rates).length, "currencies");
         return data.rates as Record<string, number>;
       }
     }
@@ -71,6 +73,7 @@ async function fetchExchangeRates(baseCurrency: string): Promise<Record<string, 
     console.error("Fallback API failed", error);
   }
 
+  console.warn(`No exchange rates found for ${baseCurrency}, using fallback`);
   return { [baseCurrency]: 1 };
 }
 

--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -77,9 +77,9 @@ async function fetchExchangeRates(baseCurrency: string): Promise<Record<string, 
 export function CurrencyProvider({ children }: { children: React.ReactNode }) {
   const [currency, setCurrencyState] = useState(() => {
     if (typeof window !== "undefined") {
-      return localStorage.getItem("selectedCurrency") || "USD";
+      return localStorage.getItem("selectedCurrency") || "INR";
     }
-    return "USD";
+    return "INR";
   });
 
   const { data: rates = {}, isLoading } = useQuery({

--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -114,7 +114,16 @@ export function CurrencyProvider({ children }: { children: React.ReactNode }) {
     const fromRate = ratesMap[fromCurrency] ?? 1;
     const toRate = ratesMap[currency] ?? 1;
 
-    return (basePrice / fromRate) * toRate;
+    const result = (basePrice / fromRate) * toRate;
+
+    // Debug logging
+    if (process.env.NODE_ENV === "development") {
+      console.log(
+        `Convert ${basePrice} from ${fromCurrency} to ${currency}: ${fromRate} -> ${toRate} = ${result}`
+      );
+    }
+
+    return result;
   };
 
   const formatPrice = (

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -324,7 +324,7 @@ export default function Index() {
                     <div className="flex items-center justify-between">
                       <span className="text-2xl font-bold text-primary">
                         {getSymbol(currency)}
-                        {Math.round(convertPrice(destination.price, "USD"))}
+                        {Math.round(convertPrice(destination.price, "INR"))}
                       </span>
                       <div className="text-primary group-hover:translate-x-2 transition-transform">
                         <ArrowRight className="w-5 h-5" />


### PR DESCRIPTION
### Purpose

Based on user feedback, this pull request addresses incorrect currency conversions and improves the user experience regarding currency selection. The primary goals were:
- To resolve inaccuracies in price conversions when switching between currencies.
- To set INR as the default currency for all new users.
- To ensure that a user's selected currency persists across sessions.
- To establish INR as the single base currency for all exchange rate calculations, removing the previous dependency on USD.

### Code changes

- **`client/contexts/CurrencyContext.tsx`**:
    - The default currency state has been updated from "USD" to "INR".
    - The `useQuery` hook for fetching exchange rates is now hardcoded to use "INR" as the base currency, ensuring all conversions originate from INR.
    - The `ratesMap` is now consistently built with INR as the base.
    - Added `console.log` statements to `fetchExchangeRates` and `convertPrice` for better debugging.

- **`client/pages/Index.tsx`**:
    - The `convertPrice` function call on the main page has been updated to specify that the input price is in "INR", ensuring correct calculations.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/bc47705556ee46e58c72409a88079ab3/neon-hub)

👀 [Preview Link](https://bc47705556ee46e58c72409a88079ab3-neon-hub.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bc47705556ee46e58c72409a88079ab3</projectId>-->
<!--<branchName>neon-hub</branchName>-->