### PR TITLE
Feat: Add offline fallback for currency exchange rates

### DIFF
--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -42,6 +42,35 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   KWD: "د.ك",
 };
 
+// Offline fallback rates relative to USD (1 USD = X local currency)
+const OFFLINE_FALLBACK_RATES: Record<string, number> = {
+  USD: 1,
+  INR: 83.25,
+  EUR: 0.92,
+  GBP: 0.79,
+  AED: 3.67,
+  SGD: 1.35,
+  AUD: 1.52,
+  CAD: 1.36,
+  JPY: 149.5,
+  CNY: 7.24,
+  CHF: 0.88,
+  HKD: 7.81,
+  NZD: 1.67,
+  SEK: 10.5,
+  NOK: 10.72,
+  DKK: 6.86,
+  ZAR: 18.5,
+  THB: 35.8,
+  MYR: 4.72,
+  IDR: 16000,
+  LKR: 329,
+  BHD: 0.376,
+  QAR: 3.64,
+  OMR: 0.385,
+  KWD: 0.305,
+};
+
 async function fetchExchangeRates(
   baseCurrency: string,
 ): Promise<Record<string, number> & { _apiBase?: string }> {

--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -86,9 +86,6 @@ async function fetchExchangeRates(
           Object.keys(data.rates).length,
           "currencies",
         );
-        console.log("[PRIMARY API] Full API Response:", data);
-        console.log("[PRIMARY API] rates.KWD =", data.rates.KWD);
-        console.log("[PRIMARY API] rates.INR =", data.rates.INR);
         const ratesWithMeta = data.rates as Record<string, number> & {
           _apiBase?: string;
         };
@@ -103,7 +100,19 @@ async function fetchExchangeRates(
   console.warn(
     `Exchange rates for ${baseCurrency} unavailable from API, using offline fallback`,
   );
-  return { [baseCurrency]: 1, _apiBase: "offline-fallback" };
+
+  // Build offline fallback rates relative to the selected base currency
+  const fallbackRates: Record<string, number> & { _apiBase?: string } = {
+    _apiBase: "offline-fallback",
+  };
+
+  const baseRate = OFFLINE_FALLBACK_RATES[baseCurrency] || 1;
+
+  for (const [code, rate] of Object.entries(OFFLINE_FALLBACK_RATES)) {
+    fallbackRates[code] = rate / baseRate;
+  }
+
+  return fallbackRates;
 }
 
 export function CurrencyProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
### Purpose

The user encountered a console error. This change improves the currency conversion feature by providing a fallback mechanism for when the primary exchange rate API is unavailable, preventing potential errors.

### Code changes

- **Added Offline Fallback Rates**: A new `OFFLINE_FALLBACK_RATES` constant was introduced with a predefined set of exchange rates relative to USD.
- **Enhanced Fallback Logic**: The `fetchExchangeRates` function was updated to use the offline rates. If the API call fails, it now calculates and returns exchange rates based on the selected base currency.
- **Removed Debugging Logs**: Removed temporary `console.log` statements from the code.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/bc47705556ee46e58c72409a88079ab3/neon-forge)

👀 [Preview Link](https://bc47705556ee46e58c72409a88079ab3-neon-forge.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 24`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bc47705556ee46e58c72409a88079ab3</projectId>-->
<!--<branchName>neon-forge</branchName>-->