### PR TITLE
Chore: Hide currency fallback warning in production

### DIFF
--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -97,9 +97,11 @@ async function fetchExchangeRates(
     console.error("[PRIMARY API] Failed:", error);
   }
 
-  console.warn(
-    `Exchange rates for ${baseCurrency} unavailable from API, using offline fallback`,
-  );
+  if (process.env.NODE_ENV === "development") {
+    console.warn(
+      `Exchange rates for ${baseCurrency} unavailable from API, using offline fallback`,
+    );
+  }
 
   // Build offline fallback rates relative to the selected base currency
   const fallbackRates: Record<string, number> & { _apiBase?: string } = {


### PR DESCRIPTION
### Purpose

The user reported seeing a warning message in the browser console when the application uses fallback exchange rates.

### Code changes

The `console.warn` statement that displays the warning for unavailable exchange rates is now wrapped in a conditional check. This ensures the warning is only visible during development (`process.env.NODE_ENV === "development"`) and is suppressed in the production environment.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/e4075219e4b34c2194f392a9cfc0ee40/pulse-haven)

👀 [Preview Link](https://e4075219e4b34c2194f392a9cfc0ee40-pulse-haven.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e4075219e4b34c2194f392a9cfc0ee40</projectId>-->
<!--<branchName>pulse-haven</branchName>-->