### PR TITLE
Fix: Remove outputDirectory from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "dist/spa",
   "env": {
     "NODE_ENV": "production"
   },


### PR DESCRIPTION
### Purpose

Based on the conversation, the user was trying to resolve a console error. This change corrects the Vercel deployment configuration to fix the underlying issue.

### Code changes

- The `outputDirectory` property was removed from `vercel.json`.
- This allows Vercel to use the default build output directory, resolving an issue with how the application was being served.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/e4075219e4b34c2194f392a9cfc0ee40/vortex-landing)

👀 [Preview Link](https://e4075219e4b34c2194f392a9cfc0ee40-vortex-landing.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 28`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e4075219e4b34c2194f392a9cfc0ee40</projectId>-->
<!--<branchName>vortex-landing</branchName>-->