### PR TITLE
Fix: Hide currency fallback warning in production

### DIFF
--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -97,9 +97,11 @@ async function fetchExchangeRates(
     console.error("[PRIMARY API] Failed:", error);
   }
 
-  console.warn(
-    `Exchange rates for ${baseCurrency} unavailable from API, using offline fallback`,
-  );
+  if (process.env.NODE_ENV === "development") {
+    console.warn(
+      `Exchange rates for ${baseCurrency} unavailable from API, using offline fallback`,
+    );
+  }
 
   // Build offline fallback rates relative to the selected base currency
   const fallbackRates: Record<string, number> & { _apiBase?: string } = {


### PR DESCRIPTION
### Purpose

Based on the conversation history, a console warning that was previously fixed has reappeared due to an accidental revert. The user wants to re-apply the fix to remove the warning message from the console.

### Code changes

The `console.warn` for unavailable exchange rates is now wrapped in a conditional check. This ensures the warning message is only displayed in the development environment and is hidden in production.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/c9b44ab47ec04550b3c0aee17e6c83fe/orbit-field)

👀 [Preview Link](https://c9b44ab47ec04550b3c0aee17e6c83fe-orbit-field.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 33`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c9b44ab47ec04550b3c0aee17e6c83fe</projectId>-->
<!--<branchName>orbit-field</branchName>-->