### PR TITLE
Feat: Implement robust multi-API currency exchange system

### DIFF
--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -56,7 +56,8 @@ const API_CONFIGS: APIConfig[] = [
     name: "exchangerate.host",
     url: (baseCurrency) =>
       `https://api.exchangerate.host/latest?base=${baseCurrency}`,
-    parser: (data) => (data.rates && typeof data.rates === "object" ? data.rates : null),
+    parser: (data) =>
+      data.rates && typeof data.rates === "object" ? data.rates : null,
     enabled: true,
   },
   {
@@ -129,7 +130,9 @@ function setCachedRates(
 
 async function fetchExchangeRates(
   baseCurrency: string,
-): Promise<Record<string, number> & { _apiBase?: string; _isCached?: boolean }> {
+): Promise<
+  Record<string, number> & { _apiBase?: string; _isCached?: boolean }
+> {
   // Try each API in order
   for (const config of API_CONFIGS) {
     if (!config.enabled) continue;
@@ -147,7 +150,11 @@ async function fetchExchangeRates(
         const data = await res.json();
         const rates = config.parser(data);
 
-        if (rates && typeof rates === "object" && Object.keys(rates).length > 0) {
+        if (
+          rates &&
+          typeof rates === "object" &&
+          Object.keys(rates).length > 0
+        ) {
           console.log(
             `[API] ✓ ${config.name} succeeded for ${baseCurrency} (${Object.keys(rates).length} rates)`,
           );


### PR DESCRIPTION
### Purpose

Based on the conversation history, this pull request implements a highly resilient, production-ready currency exchange rate system. The primary goal is to ensure users always see a valid price without any user-facing warnings, even during API downtime.

The key requirements were:
- Use a multi-API approach (Primary → Secondary → Fallback).
- Handle all API failures silently in the background, with no user-facing warnings.
- If all live APIs fail, fall back to the most recently cached successful rate, not static values.
- Automatically refresh rates from a live API once it becomes available again.

### Code changes

- **Multi-API Architecture**: Replaced the single API fetch with a configurable `API_CONFIGS` array. The system now iterates through `exchangerate.host` and `exchangerate-api.com`.
- **Removed Static Fallbacks**: The hardcoded `OFFLINE_FALLBACK_RATES` object has been removed in favor of a dynamic caching strategy.
- **Last-Known-Good Caching**: Implemented `localStorage` caching. If both live APIs fail, the system now falls back to the most recent successfully fetched rates stored in the browser.
- **Emergency Fallback**: Added a final, hardcoded "emergency" rate list as a last-resort safety net in the event that a user has no cached data and both APIs are unreachable.
- **Improved Fetch Logic**: The `fetchExchangeRates` function now includes a 5-second timeout for each API request and handles the complete fallback logic from live APIs to the cache.
- **Enhanced Logging**: Added detailed console logs to show which API source is being used (e.g., primary, secondary, cached, or emergency) for easier debugging.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/b512e6d9b15043339155d945fee548ac/echo-field)

👀 [Preview Link](https://b512e6d9b15043339155d945fee548ac-echo-field.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 34`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b512e6d9b15043339155d945fee548ac</projectId>-->
<!--<branchName>echo-field</branchName>-->