### PR TITLE
Fix: Replace secondary currency API to resolve 403 error

### DIFF
--- a/client/contexts/CurrencyContext.tsx
+++ b/client/contexts/CurrencyContext.tsx
@@ -61,13 +61,11 @@ const API_CONFIGS: APIConfig[] = [
     enabled: true,
   },
   {
-    name: "exchangerate-api.com",
-    url: (baseCurrency, apiKey) =>
-      `https://v6.exchangerate-api.com/v6/${apiKey || "free"}/latest/${baseCurrency}`,
+    name: "frankfurter.app",
+    url: (baseCurrency) =>
+      `https://api.frankfurter.app/latest?from=${baseCurrency}`,
     parser: (data) =>
-      data.conversion_rates && typeof data.conversion_rates === "object"
-        ? data.conversion_rates
-        : null,
+      data.rates && typeof data.rates === "object" ? data.rates : null,
     enabled: true,
   },
 ];


### PR DESCRIPTION
### Purpose

The user reported that the secondary currency API, `exchangerate-api.com`, was failing with a 403 Forbidden error because it cannot be called directly from the browser. This issue prevented the currency cache from being updated, forcing the application to use hardcoded emergency rates. The goal is to fix this by replacing the failing API with a browser-safe alternative to ensure the multi-API fallback system is production-safe.

### Code changes

- Replaced the secondary currency API provider from `exchangerate-api.com` to `frankfurter.app`.
- Updated the API endpoint URL to `https://api.frankfurter.app/latest?from=`.
- Modified the response parser to correctly handle the data structure from the new `frankfurter.app` API.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/522bda0b19ab4484abaec7e41fe4e2dc/pixel-lab)

👀 [Preview Link](https://522bda0b19ab4484abaec7e41fe4e2dc-pixel-lab.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>522bda0b19ab4484abaec7e41fe4e2dc</projectId>-->
<!--<branchName>pixel-lab</branchName>-->