### PR TITLE
feat: Remove Kuwaiti Dinar from currency list

### DIFF
--- a/client/lib/currency.ts
+++ b/client/lib/currency.ts
@@ -31,7 +31,6 @@ export const CURRENCIES: Currency[] = [
   { code: "BHD", name: "Bahraini Dinar", symbol: "د.ب" },
   { code: "QAR", name: "Qatari Riyal", symbol: "ر.ق" },
   { code: "OMR", name: "Omani Rial", symbol: "ر.ع." },
-  { code: "KWD", name: "Kuwaiti Dinar", symbol: "د.ك" },
 ];
 
 export const COMMON_CODES = [
@@ -69,7 +68,6 @@ export const FLAG_BY_CURRENCY: Record<string, string> = {
   BHD: "BH",
   QAR: "QA",
   OMR: "OM",
-  KWD: "KW",
 };
 
 export function getCurrencyByCode(code: string): Currency {


### PR DESCRIPTION
### Purpose

Based on the conversation history, the user wanted to remove the Kuwaiti Dinar from the "All Other Currencies" section of the currency picker in the header.

### Code changes

- Removed the Kuwaiti Dinar (KWD) from the `CURRENCIES` array in `client/lib/currency.ts`.
- Removed the corresponding entry for KWD from the `FLAG_BY_CURRENCY` map in `client/lib/currency.ts`.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7498dc67c0d46d2a8e526b58d386311/vortex-realm)

👀 [Preview Link](https://d7498dc67c0d46d2a8e526b58d386311-vortex-realm.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 37`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7498dc67c0d46d2a8e526b58d386311</projectId>-->
<!--<branchName>vortex-realm</branchName>-->