### PR TITLE
Remove Kuwaiti Dinar from the currency list

### DIFF
--- a/client/lib/currency.ts
+++ b/client/lib/currency.ts
@@ -68,7 +68,6 @@ export const FLAG_BY_CURRENCY: Record<string, string> = {
   BHD: "BH",
   QAR: "QA",
   OMR: "OM",
-  KWD: "KW",
 };
 
 export function getCurrencyByCode(code: string): Currency {

--- a/client/lib/currency.ts
+++ b/client/lib/currency.ts
@@ -31,7 +31,6 @@ export const CURRENCIES: Currency[] = [
   { code: "BHD", name: "Bahraini Dinar", symbol: "د.ب" },
   { code: "QAR", name: "Qatari Riyal", symbol: "ر.ق" },
   { code: "OMR", name: "Omani Rial", symbol: "ر.ع." },
-  { code: "KWD", name: "Kuwaiti Dinar", symbol: "د.ك" },
 ];
 
 export const COMMON_CODES = [


### PR DESCRIPTION
**Purpose**

The user wants to remove the Kuwaiti Dinar (KWD) from the currency picker in the header.

**Code changes**

- Removed "KWD" (Kuwaiti Dinar) from the `CURRENCIES` array in `client/lib/currency.ts`.
- Removed the corresponding "KWD" flag from the `FLAG_BY_CURRENCY` object in `client/lib/currency.ts`.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7498dc67c0d46d2a8e526b58d386311/glow-home)

👀 [Preview Link](https://d7498dc67c0d46d2a8e526b58d386311-glow-home.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7498dc67c0d46d2a8e526b58d386311</projectId>-->
<!--<branchName>glow-home</branchName>-->