### PR TITLE
Fix: Use INR for currency conversion on destination page

### DIFF
--- a/client/pages/Destinations.tsx
+++ b/client/pages/Destinations.tsx
@@ -377,7 +377,7 @@ export default function Destinations() {
                             <span className="text-2xl font-bold text-primary">
                               {getSymbol(currency)}
                               {Math.round(
-                                convertPrice(destination.price, "USD"),
+                                convertPrice(destination.price, "INR"),
                               )}
                             </span>
                             <div className="text-primary group-hover:translate-x-2 transition-transform">


### PR DESCRIPTION
### Purpose

The user's goal is to standardize the currency conversion across the application. They requested that all currency conversions use INR as the single base currency, as the destination page was incorrectly converting from USD.

### Code changes

The `convertPrice` function on the `Destinations.tsx` page was updated. The base currency for the conversion was changed from "USD" to "INR" to align with the requirement of using a single base currency.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7498dc67c0d46d2a8e526b58d386311/nova-field)

👀 [Preview Link](https://d7498dc67c0d46d2a8e526b58d386311-nova-field.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 40`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7498dc67c0d46d2a8e526b58d386311</projectId>-->
<!--<branchName>nova-field</branchName>-->