### PR TITLE
Remove hero section from Destinations page

### DIFF
--- a/client/pages/Destinations.tsx
+++ b/client/pages/Destinations.tsx
@@ -187,18 +187,6 @@ export default function Destinations() {
 
   return (
     <Layout>
-      {/* Hero Section */}
-      <section className="bg-gradient-to-br from-blue-50 to-orange-50 py-12">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl md:text-5xl font-display font-bold text-foreground mb-4">
-            Explore Destinations
-          </h1>
-          <p className="text-gray-600 max-w-2xl">
-            Find your perfect travel destination from our curated collection
-          </p>
-        </div>
-      </section>
-
       {/* Destination Chooser */}
       <section className="bg-white border-b border-gray-200 py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
### Purpose
Based on the conversation, the user wanted to remove the "Explore Destinations" hero section from the Destinations page to simplify the user interface. The goal is to have the "Choose your destination" section appear at the top of the page.

### Code changes
- The hero section, which included the `<h1>Explore Destinations</h1>` title and a descriptive paragraph, has been removed from the `client/pages/Destinations.tsx` file.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7498dc67c0d46d2a8e526b58d386311/pulse-works)

👀 [Preview Link](https://d7498dc67c0d46d2a8e526b58d386311-pulse-works.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 41`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7498dc67c0d46d2a8e526b58d386311</projectId>-->
<!--<branchName>pulse-works</branchName>-->